### PR TITLE
Improve login interaction

### DIFF
--- a/consulta_societaria.py
+++ b/consulta_societaria.py
@@ -38,7 +38,15 @@ class DominioConsultaSocietaria:
             if not self.main_window:
                 return False
             self.main_window.set_focus()
-            keyboard.send_keys(self.password)
+            # garante que o campo de senha esteja ativo antes de digitar
+            try:
+                password_edit = self.main_window.child_window(control_type="Edit")
+                password_edit.wait("ready", timeout=5)
+                password_edit.click_input()
+                password_edit.type_keys(self.password, with_spaces=True)
+            except Exception:  # pragma: no cover - depende da UI
+                keyboard.send_keys(self.password)
+
             keyboard.send_keys("%o")  # Alt+O
             time.sleep(2)
             return True

--- a/script.py
+++ b/script.py
@@ -45,7 +45,14 @@ class DominioAutomation:
                 return False
 
             self.main_window.set_focus()
-            keyboard.send_keys(self.password)
+            # garante que o campo de senha esteja visível antes de digitar
+            try:
+                password_edit = self.main_window.child_window(control_type="Edit")
+                password_edit.wait("ready", timeout=5)
+                password_edit.click_input()
+                password_edit.type_keys(self.password, with_spaces=True)
+            except Exception:  # pragma: no cover - depende da UI
+                keyboard.send_keys(self.password)
             keyboard.send_keys("%o")  # Alt+O
             time.sleep(2)
             return True


### PR DESCRIPTION
## Summary
- use type_keys on password field when focusing
- fallback to send_keys if direct typing fails
- normalize newline at end of script

## Testing
- `python -m py_compile consulta_societaria.py script.py`

------
https://chatgpt.com/codex/tasks/task_e_68717761876c8326b179e28f917ca78f