### PR TITLE
Enable manual login option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Crie um arquivo `.env` na raiz do projeto:
 DOMINIO_PASSWORD=sua_senha_do_dominio
 CAPTCHA_2CAPTCHA_KEY=sua_chave_do_2captcha
 TEST_MODE=true  # opcional, processa somente as 3 primeiras empresas
+MANUAL_LOGIN=true  # se verdadeiro, o script aguardará o login manual
 ```
 
 ## ⚙️ Configuração
@@ -144,6 +145,19 @@ pip install -r requirements.txt --force-reinstall
 - Inspecione a janela do sistema Domínio
 - Ajuste os identificadores usados no código
 - Use `pyautogui.screenshot('debug.png')` para auxiliar no debug
+
+## ❓ FAQ
+
+### O script exibe `TimeoutError` ao iniciar
+Verifique se a constante `APP_SHORTCUT` aponta para o executável correto do Domínio e se a janela de login abre normalmente fora do script.  
+Caso o sistema demore a iniciar, aumente o tempo de espera na função `init_app`.
+
+### A senha não é inserida na janela de login
+Confirme que o foco está no campo de senha e que o uso de área de transferência não está bloqueado.
+Se necessário, altere o método de digitação para `keyboard.send_keys`.
+
+### Posso fazer o login manualmente?
+Defina `MANUAL_LOGIN=true` no arquivo `.env`. O script abrirá o Domínio e aguardará você concluir o login manualmente antes de continuar.
 
 ## 📞 Suporte
 

--- a/consulta_societaria.py
+++ b/consulta_societaria.py
@@ -9,6 +9,8 @@ from typing import Dict, List
 import requests
 from dotenv import load_dotenv
 from pywinauto import Application, keyboard
+import pyautogui
+import pyperclip
 
 APP_SHORTCUT = r"C:\\Contabil\\contabil.exe /registro"
 
@@ -19,6 +21,7 @@ class DominioConsultaSocietaria:
         load_dotenv()
         self.password = os.getenv("DOMINIO_PASSWORD", "")
         self.test_mode = os.getenv("TEST_MODE", "false").lower() in ("1", "true", "yes")
+        self.manual_login = os.getenv("MANUAL_LOGIN", "false").lower() in ("1", "true", "yes")
         self.app: Application | None = None
         self.main_window = None
         self.log_json: List[Dict] = []
@@ -28,17 +31,38 @@ class DominioConsultaSocietaria:
     # --------------------------------------------------------------
     def init_app(self) -> None:
         """Abre o aplicativo Dom\u00ednio."""
-        self.app = Application(backend="uia").start(APP_SHORTCUT)
+        # inicia o Dom\u00ednio sem aguardar ocioso para evitar travamentos
+        self.app = Application(backend="uia").start(APP_SHORTCUT, wait_for_idle=False)
+        time.sleep(2)  # pequena pausa para a janela ser criada
+
+        # conecta na janela principal, que pode demorar alguns segundos para surgir
+        self.app.connect(title_re=".*Dom\u00ednio.*", timeout=60)
         self.main_window = self.app.window(title_re=".*Dom\u00ednio.*")
         self.main_window.wait("visible", timeout=60)
 
     def login(self) -> bool:
-        """Realiza login enviando a senha."""
+        """Realiza login automatico ou aguarda login manual."""
         try:
             if not self.main_window:
                 return False
+            self.main_window.wait("ready", timeout=30)
             self.main_window.set_focus()
-            keyboard.send_keys(self.password)
+
+            if self.manual_login:
+                print("Aguardando login manual. Realize o login e pressione Enter...")
+                input()
+                return True
+
+            try:
+                password_edit = self.main_window.child_window(control_type="Edit")
+                password_edit.wait("ready", timeout=5)
+                password_edit.click_input()
+                pyperclip.copy(self.password)
+                pyautogui.hotkey("ctrl", "v")
+                time.sleep(0.5)
+            except Exception:  # pragma: no cover - depende da UI
+                keyboard.send_keys(self.password)
+
             keyboard.send_keys("%o")  # Alt+O
             time.sleep(2)
             return True


### PR DESCRIPTION
## Summary
- add `MANUAL_LOGIN` option to wait for manual login
- mention new variable in README with FAQ
- update login routines to support manual login

## Testing
- `python -m py_compile consulta_societaria.py script.py`


------
https://chatgpt.com/codex/tasks/task_e_68717761876c8326b179e28f917ca78f